### PR TITLE
Add an ability to skip tests matching a regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ by adding
 - support to (de-)select or skip parametrized tests without needing to specify test instance qualifiers
 - support for blank and comment lines in the selection files
 - better integration with the `pytest-xdist`, plugin warning and error messages are passed to the master node with proper stdout or stderr outputs
-- an ability to skip tests matching a certain regexp (the skipline should start with `@regexp:`)
+- an ability to select/skip parameters combinations matching a certain regular expression.
+Put your regexp in the square brackets as a raw string and end the line with `@regexp` suffix:
+`file.py::test[r"REGEXP"]@regexp`
 
 
 Usage
@@ -41,7 +43,8 @@ Example::
     test_parametrized[1]
     test_parametrized
     tests/test_foo.py::test_other
-    @regexp:test_parametrized_complex\[[8|16]-.*-.*\]
+    test_parametrized_complex[r"[8|16]-.*-.*"]@regexp
+    tests/test_foo.py::test_params[r"int32-.*-.*"]@regexp
 
     $~ pytest --select-from-file selection.txt
     $~ pytest --deselect-from-file selection.txt

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ by adding
 - support to (de-)select or skip parametrized tests without needing to specify test instance qualifiers
 - support for blank and comment lines in the selection files
 - better integration with the `pytest-xdist`, plugin warning and error messages are passed to the master node with proper stdout or stderr outputs
+- an ability to skip tests matching a certain regexp (the skipline should start with `@regexp:`)
 
 
 Usage
@@ -40,6 +41,7 @@ Example::
     test_parametrized[1]
     test_parametrized
     tests/test_foo.py::test_other
+    @regexp:test_parametrized_complex\[[8|16]-.*-.*\]
 
     $~ pytest --select-from-file selection.txt
     $~ pytest --deselect-from-file selection.txt

--- a/pytest_skip/plugin.py
+++ b/pytest_skip/plugin.py
@@ -55,7 +55,7 @@ class SelectConfig:
                     else:
                         test_name, regexp = match.groups()
                         regexps_list = self.test_regexps.get(test_name, set())
-                        regexps_list.add(regexp)
+                        regexps_list.add(re.compile(regexp))
                         self.test_regexps[test_name] = regexps_list
                 else:
                     self.test_names.add(test_name)

--- a/pytest_skip/plugin.py
+++ b/pytest_skip/plugin.py
@@ -49,8 +49,7 @@ class SelectConfig:
                         warnings.warn(
                             f"The skipline '{test_name}' has a regexp "
                             "suffix but doesn't contain an actual regexp. The line will be "
-                            "treated as a non-regexp."
-                        )
+                            "treated as a non-regexp.")
                         self.test_names.add(test_name[:-len(self.regexp_test_name_suffix)])
                     else:
                         test_name, regexp = match.groups()

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -232,6 +232,20 @@ def test_missing_selection_file_fails(testdir, option_name):
             },
             [],
         ),
+        (
+            SKIP_OPT,
+            [
+                "test_a[r\"1-1\"]@regexp",
+                "{testfile}::test_a[r\"1-2\"]@regexp",
+                "test_a[r\".*-3\"]@regexp",
+            ],
+            0,
+            {
+                "passed": 1,
+                "skipped": 3
+            },
+            [],
+        ),
     ),
 )
 def test_tests_are_selected(  # pylint: disable=R0913, disable=R0917

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -407,43 +407,36 @@ def test_with_regexp_as_param(testdir, option_name, select_content, exit_code, o
     result.assert_outcomes(**outcomes)
 
 
-@pytest.mark.parametrize(
-    "skipfile_str,is_regexp,test_name,params,",
-    [
-        ("file.py::test_name[r\"param-match\"]@regexp", True, "file.py::test_name", "param-match"),
-        ("test_name[r\"param-match\"]@regexp", True, "test_name", "param-match"),
-        (
-            "folder/file.py::test_name[r\"some_thing\"]@regexp/something.py::test_name/folder/test.py::test_name",
-            False,
-            None,
-            None,
-        ),
-        (
-            "folder/file.py::test_name[r\"some_thing/something.py::test_name/folder/test.py::test_name[\"not-regexp\"]",
-            False,
-            None,
-            None,
-        ),
-        (
-            "folder/file.py::test_name[r\"some_thing\"]/something.py::test_name/folder/test.py::test_name[r\"param-match\"]@regexp",
-            True,
-            "folder/file.py::test_name[r\"some_thing\"]/something.py::test_name/folder/test.py::test_name",
-            "param-match"
-        ),
-        (
-            "folder/file.py[r\"some_thing\"]",
-            False,
-            None,
-            None,
-        ),
-        (
-            "folder/file.py[r\"some_\"thing\"\"]@regexp",
-            True,
-            "folder/file.py",
-            "some_\"thing\"",
-        )
-    ]
-)
+@pytest.mark.parametrize("skipfile_str,is_regexp,test_name,params,", [
+    ("file.py::test_name[r\"param-match\"]@regexp", True, "file.py::test_name", "param-match"),
+    ("test_name[r\"param-match\"]@regexp", True, "test_name", "param-match"),
+    (
+        "folder/file.py::test_name[r\"some_thing\"]@regexp/something.py::test_name/folder/test.py::test_name",
+        False,
+        None,
+        None,
+    ),
+    (
+        "folder/file.py::test_name[r\"some_thing/something.py::test_name/folder/test.py::test_name[\"not-regexp\"]",
+        False,
+        None,
+        None,
+    ),
+    ("folder/file.py::test_name[r\"some_thing\"]/something.py::test_name/folder/test.py::test_name[r\"param-match\"]@regexp",
+     True,
+     "folder/file.py::test_name[r\"some_thing\"]/something.py::test_name/folder/test.py::test_name",
+     "param-match"), (
+         "folder/file.py[r\"some_thing\"]",
+         False,
+         None,
+         None,
+     ), (
+         "folder/file.py[r\"some_\"thing\"\"]@regexp",
+         True,
+         "folder/file.py",
+         "some_\"thing\"",
+     )
+])
 def test_regexp_match(skipfile_str, is_regexp, test_name, params):
     res_match = re.match(SelectConfig.regexp_test_name_pattern, skipfile_str)
     assert (res_match is not None) is is_regexp

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -186,6 +186,25 @@ def test_missing_selection_file_fails(testdir, option_name):
                 r"\s+- test_that_does_not_exist",
             ],
         ),
+        (
+            SKIP_OPT,
+            [r"@regexp:test_a\[1-.*\]"],
+            0,
+            {
+                "skipped": 4
+            },
+            [],
+        ),
+        (
+            SKIP_OPT,
+            [r"@regexp:test_a\[.*-[2|3]\]"],
+            0,
+            {
+                "passed": 2,
+                "skipped": 2
+            },
+            [],
+        ),
     ),
 )
 def test_tests_are_selected(  # pylint: disable=R0913, disable=R0917

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -1,5 +1,5 @@
-import pytest
 import re
+import pytest
 
 from pytest_skip.plugin import SelectConfig
 

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -1,4 +1,7 @@
 import pytest
+import re
+
+from pytest_skip.plugin import SelectConfig
 
 TEST_CONTENT = """
     import pytest
@@ -42,6 +45,20 @@ TEST_CONTENT_WITH_NESTED_BRACKETS = """
     )
     def test_b(a, b):
         assert b in ('a[1]', '4')
+"""
+
+TEST_CONTENT_WITH_REGEXP_AS_PARAM = """
+    import pytest
+
+    @pytest.mark.parametrize(
+        ('a'),
+        (
+            "r\\"a.*\\"",
+            "r\\"abc2\\""
+        )
+    )
+    def test_a(a):
+        assert True
 """
 
 SELECT_OPT = "--select-from-file"
@@ -188,7 +205,7 @@ def test_missing_selection_file_fails(testdir, option_name):
         ),
         (
             SKIP_OPT,
-            [r"@regexp:test_a\[1-.*\]"],
+            ["test_a[r\"1-.*\"]@regexp"],
             0,
             {
                 "skipped": 4
@@ -197,7 +214,17 @@ def test_missing_selection_file_fails(testdir, option_name):
         ),
         (
             SKIP_OPT,
-            [r"@regexp:test_a\[.*-[2|3]\]"],
+            ["test_a[r\".*-[2|3]\"]@regexp"],
+            0,
+            {
+                "passed": 2,
+                "skipped": 2
+            },
+            [],
+        ),
+        (
+            SKIP_OPT,
+            ["{testfile}::test_a[r\".*-[2|3]\"]@regexp"],
             0,
             {
                 "passed": 2,
@@ -335,3 +362,80 @@ def test_nested_brackets(testdir, option_name, select_content, exit_code, outcom
 
     assert result.ret == exit_code
     result.assert_outcomes(**outcomes)
+
+
+@pytest.mark.parametrize(
+    ("option_name", "select_content", "exit_code", "outcomes"),
+    [
+        (
+            SKIP_OPT,
+            [
+                "{testfile}::test_a[r\"a.*\"]",
+            ],
+            0,
+            {
+                "passed": 1,
+                "skipped": 1
+            },
+        ),
+    ],
+)
+def test_with_regexp_as_param(testdir, option_name, select_content, exit_code, outcomes):
+    testfile = testdir.makefile(".py", TEST_CONTENT_WITH_REGEXP_AS_PARAM)
+    args = ["-v", "-Walways"]
+    select_file = testdir.makefile(
+        ".txt",
+        *[line.format(testfile=testfile.relto(testdir.tmpdir)) for line in select_content],
+    )
+    args.extend([option_name, select_file])
+    result = testdir.runpytest(*args)
+    assert result.ret == exit_code
+    result.assert_outcomes(**outcomes)
+
+
+@pytest.mark.parametrize(
+    "skipfile_str,is_regexp,test_name,params,",
+    [
+        ("file.py::test_name[r\"param-match\"]@regexp", True, "file.py::test_name", "param-match"),
+        ("test_name[r\"param-match\"]@regexp", True, "test_name", "param-match"),
+        (
+            "folder/file.py::test_name[r\"some_thing\"]@regexp/something.py::test_name/folder/test.py::test_name",
+            False,
+            None,
+            None,
+        ),
+        (
+            "folder/file.py::test_name[r\"some_thing/something.py::test_name/folder/test.py::test_name[\"not-regexp\"]",
+            False,
+            None,
+            None,
+        ),
+        (
+            "folder/file.py::test_name[r\"some_thing\"]/something.py::test_name/folder/test.py::test_name[r\"param-match\"]@regexp",
+            True,
+            "folder/file.py::test_name[r\"some_thing\"]/something.py::test_name/folder/test.py::test_name",
+            "param-match"
+        ),
+        (
+            "folder/file.py[r\"some_thing\"]",
+            False,
+            None,
+            None,
+        ),
+        (
+            "folder/file.py[r\"some_\"thing\"\"]@regexp",
+            True,
+            "folder/file.py",
+            "some_\"thing\"",
+        )
+    ]
+)
+def test_regexp_match(skipfile_str, is_regexp, test_name, params):
+    res_match = re.match(SelectConfig.regexp_test_name_pattern, skipfile_str)
+    assert (res_match is not None) is is_regexp
+    if not is_regexp:
+        return
+
+    res_test_name, res_params = res_match.groups()
+    assert res_test_name == test_name
+    assert res_params == params


### PR DESCRIPTION
<b>How to use: </b>
This implementation only supports regexpes in tests parameters, for example: `test[r".*-int32"]@regexp`. A line in the skiplist should have a `@regexp` suffix in order to be recognized as a line containing a regexp (in order to avoid conflicts with tests that actually have a raw regexp string as a parameter). One can assign several regexpes to the same test:
```
file.py::test[r".*-int32"]@regexp
test[r"8-16-.*"]@regexp
test[r"8-24-uint8-.*"]@regexp
```

<b>Motivation: </b>
Making a skiplist with tests that have a lot of parameters may require you to add hundreds of lines just to disable the test for one specific parameter value (for [example](https://github.com/intel/intel-xpu-backend-for-triton/blob/12fdf3f229fe3ef580d6ec9e7b8b9f5c6bae4dd6/scripts/skiplist/a770/language.txt#L1-L164)). This makes the skiplist unnecessary bulky and really hard to read.

The unwillingness to make the skiplist unreadable may discourage developers to skip individual parameters combination in favor of skipping the whole test altogether, which can negatively affect the pass-rate in their metrics. Adding an option to skip by a regexp may make the skiplist much cleaner in certain scenarios and encourage developers to only skip the tests that are actually failing.

<b>Implementation: </b>

Along with the `SelectConfig.test_names` field, there is now also a `SelectConfig.test_regexps` dictionary that matches the tests to their regexpes from the skiplist.
```
--- skiplist ---
path/file.py::test[r".*-int32"]@regexp
test2[r"int8-.*"]@regexp
test2[r"uint8-16-.*"]@regexp
path/file.py::test2[r"int32-.*"]@regexp

--- SelectConfig.test_regexps ---
self.test_regexps["path/file.py::test"] = [r".*-int32"]
self.test_regexps["test2"] = [r"int8-.*", r"uint8-16-.*"]
self.test_regexps["path/file.py::test2"] = [r"int32-.*"]
```
When deciding whether a test should be skipped (`SelectConfig.no_test_items_match` func) we lookup for a regexp-list at the `test_regexps` dictionary and iterate through regexpes for the test.

<b>Performance testing:</b>
<b>1. intel-triton-xpu use case</b>
20_531 tests, 2_923 tests in the skip-list, 160 of them are regexpes:
```
BEFORE PR: 0.106s
AFTER PR: 0.114s
```

<b>2. Synthetic test</b>

```
test_path_len=140
param_list_len=64
total_test_line_len=204 (~90 in triton)

N_tests  N_skip   N_regex  Time (main)   Time (this PR)
1_000    10       1        0.0024 sec    0.003 sec
1_000    100      10       0.0028 sec    0.0037 sec
1_000    500      50       0.0049 sec    0.0067 sec
30_000   300      30       0.0689 sec    0.0871 sec
30_000   3_000    300      0.082 sec     0.1063 sec
30_000   15_000   1_500    0.1434 sec    0.2075 sec
100_000  1_000    100      0.2255 sec    0.2883 sec
100_000  10_000   1_000    0.2763 sec    0.3623 sec
100_000  50_000   5_000    0.5351 sec    0.721 sec

~32% perf degradation
```

<details><summary>script to measure</summary>

```python
import random
import re
import tempfile
import time
from pathlib import Path
from timeit import default_timer as timer
from typing import List
import string

from pytest_skip.plugin import SelectConfig, SelectPlugin, SelectOption
PATH_LEN=128

def random_string(length: int) -> str:
    letters = string.ascii_letters + string.digits
    return ''.join(random.choices(letters, k=length))

def generate_test_items(n: int) -> List[str]:
    return [f"{random_string(PATH_LEN)}::test_func[{i}-{'-'.join([random_string(4) for j in range(16)])}]" for i in range(n)]


def generate_skip_list(test_items: List[str], total: int, regex_count: int) -> List[str]:
    exact_count = total - regex_count
    selected = random.sample(test_items, total)
    exact = selected[:exact_count]
    regex_targets = selected[exact_count:]

    skip_lines = list(exact)
    for item in regex_targets:
        match = re.match(r"^(.*)\[(.*)\]$", item)
        if not match:
            continue
        test_base, param = match.groups()
        param_class = param.split('-')[1]
        skip_lines.append(f'{test_base}[r"{param_class}"]@regexp')
    return skip_lines


def benchmark_selectplugin(N: int, X: int, Y: int):
    assert Y <= X <= N
    test_items = generate_test_items(N)
    skip_list = generate_skip_list(test_items, X, Y)

    with tempfile.NamedTemporaryFile(mode='w+', delete=False) as f:
        for line in skip_list:
            f.write(line + '\n')
        f_path = f.name

    class DummyConfig:
        def getoption(self, key):
            return {
                "skipfromfile": f_path,
                "selectfromfile": None,
                "deselectfromfile": None,
                "selectfailonmissing": False
            }.get(key, None)

    class DummyItem:
        def __init__(self, name, nodeid):
            self.name = name
            self.nodeid = nodeid
            self.markers = []

        def add_marker(self, marker):
            self.markers.append(marker)

    items = [DummyItem(name.split('::')[1], name) for name in test_items]

    t1 = timer()
    config = SelectConfig(DummyConfig(), SelectOption.SKIP, f_path, False)
    plugin = SelectPlugin()
    plugin._get_selections(config, items)
    t2 = timer()
    return round(t2 - t1, 4)


def main():
    res = "N_tests\tN_skip\tN_regex\tTime\n"
    for N in [1_000, 30_000, 100_000]:
        for N_skip_ratio in [0.01, 0.1, 0.5]:
            N_skip = int(N * N_skip_ratio)
            N_regex = int(N_skip * 0.1)
            t = benchmark_selectplugin(N, N_skip, N_regex)
            res += f"{N}\t{N_skip}\t{N_regex}\t{t} sec\n"
    print(res)


if __name__ == "__main__":
    main()
```

</details>

cc @anmyachev @vlad-penkin 