### PR TITLE
[FIX-#1] Fix '--select-fail-on-missing' behavior without xdist

### DIFF
--- a/pytest_skip/plugin.py
+++ b/pytest_skip/plugin.py
@@ -179,6 +179,7 @@ class SelectPlugin:
                 item.add_marker(pytest.mark.skip(reason="Deselected by pytest-skip"))
             else:
                 deselected_items.append(item)
+        self.seen_test_names = select_config.seen_test_names
         return selected_items, deselected_items
 
     def pytest_collection_modifyitems(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,8 @@
+import pytest
+
 pytest_plugins = ["pytester"]
+
+
+@pytest.fixture
+def is_xdist_installed(pytestconfig: pytest.Config):
+    return pytestconfig.pluginmanager.hasplugin("xdist")

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -1,5 +1,9 @@
 import pytest
 
+# FIXME: this needs a refactoring where we make each test a structure
+# what contains the failing/passing combinations as a field
+TEST_CONTENT_PASSING_COMBINATIONS = ("test_a[1-1]", "test_a[1-4]")
+TEST_CONTENT_FAILING_COMBINATIONS = ("test_a[1-2]", "test_a[1-3]")
 TEST_CONTENT = """
     import pytest
 
@@ -212,28 +216,39 @@ def test_tests_are_selected(  # pylint: disable=R0913, disable=R0917
         result.stdout.re_match_lines_random(stdout_lines)
 
 
+@pytest.mark.parametrize("use_xdist", (False, True))
+@pytest.mark.parametrize("has_missing_tests", (False, True))
 @pytest.mark.parametrize("deselect", (False, True))
-def test_fail_on_missing(testdir, deselect):
+def test_fail_on_missing(is_xdist_installed, testdir, deselect, has_missing_tests, use_xdist):
+    if use_xdist and not is_xdist_installed:
+        pytest.skip("xdist is not installed")
+
     testdir.makefile(".py", TEST_CONTENT)
-    selectfile = testdir.makefile(".txt", "test_a[1-1]", "test_a[2-1]")
+
+    existing_tests = TEST_CONTENT_FAILING_COMBINATIONS if deselect else TEST_CONTENT_PASSING_COMBINATIONS
+    file_tests = ("test_a[1-1]", "test_a[2-1]") if has_missing_tests else existing_tests
+    selectfile = testdir.makefile(".txt", *file_tests)
     result = testdir.runpytest(
         "-v",
         "--select-fail-on-missing",
+        "-n 1" if use_xdist else "",
         f"--{'de' if deselect else ''}select-from-file",  # pylint: disable=W1405
         selectfile,
     )
-    assert result.ret == 4
+
+    assert result.ret == (4 if has_missing_tests else 0)
     if deselect:
         first_line = r"pytest-skip: Not all deselected tests exist \(or have been selected otherwise\)."
         second_line = r"Missing deselected test names:"
     else:
         first_line = r"pytest-skip: Not all selected tests exist \(or have been deselected otherwise\)."
         second_line = r"Missing selected test names:"
-    result.stderr.re_match_lines([
-        first_line,
-        second_line,
-        # "  - test_a[2-1]",
-    ])
+    if has_missing_tests:
+        result.stderr.re_match_lines([
+            first_line,
+            second_line,
+            # "  - test_a[2-1]",
+        ])
 
 
 @pytest.mark.parametrize(("fail_on_missing", "deselect"), [(True, False), (True, True),


### PR DESCRIPTION
Closes #1 

Adds the population of the `SelectPlugin.seen_test_names` field to the `SelectPlugin._get_selections`