### PR TITLE
Update 'build-test.yml' job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -37,15 +37,10 @@ jobs:
           pip install --upgrade pre-commit
           python3 -m pre_commit run --show-diff-on-failure --color=always --all-files --verbose
 
-      - name: Run unit tests without xdist
+      - name: Run unit tests
         run: |
           pip install .
           pytest tests/
-
-      - name: Run unit tests with xdist
-        run: |
-          pip install pytest-xdist
-          pytest -n 2 tests/
 
       - name: Check coexistence with pytest-select plugin
         id: test_with_pytest_select


### PR DESCRIPTION
<s>Adds testing on python 3.14 in CI</s> and removes unnecessary tests run with xdist

python 3.14 is only available with `allow-prereleases: true` flag, don't think we should set it, it might be better to wait for a release