### PR TITLE
Add --xfail-from-file/--xfail-test options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is a [pytest](https://pytest.org) plugin which allows to (de-)select or ski
 pytest-skip expands upon the capabilities of the original [pytest-select](https://github.com/ulope/pytest-select) plugin
 by adding
 - `--skip-from-file` option to skip tests instead of deselecting
-- support to (de-)select or skip parametrized tests without needing to specify test instance qualifiers
+- `--xfail-from-file` option to mark tests as expected to fail (xfail) instead of deselecting or skipping
+- support to (de-)select, skip or xfail parametrized tests without needing to specify test instance qualifiers
 - support for blank and comment lines in the selection files
 - better integration with the `pytest-xdist`, plugin warning and error messages are passed to the master node with proper stdout or stderr outputs
 - sharding functionality to distribute tests across several nodes
@@ -23,21 +24,42 @@ This plugin adds new command line options to pytest:
 - ``--select-from-file``
 - ``--deselect-from-file``
 - ``--skip-from-file``
+- ``--xfail-from-file``
 - ``--select-test``
 - ``--deselect-test``
 - ``--skip-from-test``
+- ``--xfail-test``
 - ``--select-fail-on-missing``
+- ``--xfail-strict``
 - ``--num-shards``, ``--shard-id`` and ``--sharding-mode``
 
-The first three expect an argument that resolves to one or multiple, semicolon-separated, UTF-8 encoded text file(s)
-containing one test name per line. Text file may contain blank and comment lines (starts from `#`). All three
-(select, deselect, skip) options can be used simultaneously.
+The first four expect an argument that resolves to one or multiple, semicolon-separated, UTF-8 encoded text file(s)
+containing one test name per line. Text file may contain blank and comment lines (starts from `#`). All four
+(select, deselect, skip, xfail) options can be used simultaneously.
 
-The next three expect one or multiple, semicolon-separated, test names to be selected, deselected or skipped.
+The next four expect one or multiple, semicolon-separated, test names to be selected, deselected, skipped or marked xfail.
 
-The next one changes the behaviour in case (de-)selected or skipped test names are missing from the to-be executed tests.
+The next one changes the behaviour in case (de-)selected, skipped or xfailed test names are missing from the to-be executed tests.
 By default a warning is emitted and the remaining selected tests are executed as normal.
 By using the ``--select-fail-on-missing`` flag this behaviour can be changed to instead abort execution in that case.
+
+``--skip-from-file``/``--skip-test`` and ``--xfail-from-file``/``--xfail-test`` differ in an important way: a skipped
+test's body never runs, while an xfailed test's body does run and is simply expected to fail. If an xfailed test
+unexpectedly passes, it is reported as ``XPASS`` rather than a plain pass, which is useful to surface tests that were
+expected to fail but no longer do.
+
+**Important**: by default, an ``XPASS`` does **not** fail the overall pytest run or change its exit code — this
+matches pytest's own default (non-strict) ``xfail`` behaviour. In other words, ``--xfail-from-file``/``--xfail-test``
+alone will surface a regression-fix in the ``XPASS`` line of the output, but it will **not** turn a CI run red on
+its own. If you want an unexpected pass to actually fail the run (and the exit code), either pass ``--xfail-strict``
+on the command line, or set ``xfail_strict = true`` in your own project's pytest configuration (which applies to
+all xfail markers, not just the ones added by this plugin).
+
+If a test name is listed in **both** ``--xfail-from-file``/``--xfail-test`` **and**
+``--skip-from-file``/``--skip-test`` or ``--deselect-from-file``/``--deselect-test``, the skip/deselect option takes
+precedence: the test is skipped or deselected as usual, and the xfail marker is **not** applied to it (marking a
+test that never runs as xfail would be meaningless). This is not a silent no-op: pytest-skip emits a warning naming
+the colliding test so the conflict isn't hidden.
 
 The sharding parameters allow users to split the test sets into even portions across multiple shards for parallel execution.
 The tests that are filtered out for a shard will be deselected.
@@ -67,11 +89,18 @@ Example::
     $~ cat skip2.txt
     test_parametrized[r"[579]"]@regexp
 
+    $~ cat xfail.txt
+    test_parametrized[3]
+    test_parametrized_complex[r"32-.*-.*"]@regexp
+
     $~ pytest --select-from-file select.txt
     $~ pytest --deselect-from-file deselect.txt
     $~ pytest --select-from-file select.txt --deselect-from-file deselect.txt --skip-from-file skip1.txt:skip2.txt
     $~ pytest --skip-from-file skip1.txt:skip2.txt --num-shards=4 --shard-id=0 --sharding-mode=round-robin
     $~ pytest --skip-from-file skip1.txt:skip2.txt --num-shards=4 --shard-id=0 --sharding-mode=contiguous-split
+    $~ pytest --xfail-from-file xfail.txt
+    $~ pytest --xfail-test "test_parametrized[3];test_parametrized[4]"
+    $~ pytest --xfail-from-file xfail.txt --xfail-strict
 
 
 Install from source
@@ -105,6 +134,18 @@ the maximum command length.
 
 Version History
 ---------------
+- ``v0.3.0`` (unreleased):
+    - Added `--xfail-from-file` and `--xfail-test` options to mark tests as expected to fail (xfail) instead of
+      deselecting or skipping them. Unlike skip, an xfailed test's body still runs; an unexpected pass is reported
+      as `XPASS`. By default this does NOT fail the run (matching pytest's own non-strict xfail default); use the
+      new `--xfail-strict` option (or your project's `xfail_strict = true` config) if you want an unexpected pass
+      to fail the run.
+    - Added `--xfail-strict` option to make xfail marks applied by this plugin strict.
+    - When a test name collides between `--xfail-from-file`/`--xfail-test` and
+      `--skip-from-file`/`--skip-test`/`--deselect-from-file`/`--deselect-test`, skip/deselect now deliberately take
+      precedence and the xfail marker is not applied; a warning is emitted naming the collision instead of silently
+      dropping the xfail request.
+
 - ``v0.2.0`` - 9/12/2025:
     - Added sharding functionality (`--num-shards`, `--shard-id`, `--sharding-mode`) to distribute tests across multiple nodes
     - Added ability to (de-)select or skip tests directly by name (`--select-test`, `--deselect-test`, `--skip-test`)

--- a/pytest_skip/plugin.py
+++ b/pytest_skip/plugin.py
@@ -14,6 +14,7 @@ class SelectOption(Enum):
     SELECT = ("selectfromfile", "selecttest")
     DESELECT = ("deselectfromfile", "deselecttest")
     SKIP = ("skipfromfile", "skiptest")
+    XFAIL = ("xfailfromfile", "xfailtest")
 
 
 @dataclass
@@ -186,6 +187,7 @@ class SelectConfig:
     select: Optional[Matcher]
     deselect: Optional[Matcher]
     skip: Optional[Matcher]
+    xfail: Optional[Matcher]
     fail_on_missing: bool
 
     def check_missing_tests(self):
@@ -219,7 +221,10 @@ class SelectConfig:
             fail_on_missing) if any(matchers.values()) else None
 
     def get_matchers(self) -> Dict[str, Optional[Matcher]]:
-        return {k: v for k in ("select", "deselect", "skip") if (v := getattr(self, k)) is not None}
+        return {
+            k: v
+            for k in ("select", "deselect", "skip", "xfail") if (v := getattr(self, k)) is not None
+        }
 
 
 def pytest_addoption(parser: pytest.Parser):
@@ -259,6 +264,14 @@ def pytest_addoption(parser: pytest.Parser):
         help="Mark tests from one or multiple, semicolon-separated, file(s) as skipped.",
     )
     select_group.addoption(
+        "--xfail-from-file",
+        action="store",
+        dest="xfailfromfile",
+        default=None,
+        help="Mark tests from one or multiple, semicolon-separated, file(s) as xfail "
+        "(expected to fail).",
+    )
+    select_group.addoption(
         "--select-test",
         action="store",
         dest="selecttest",
@@ -277,7 +290,14 @@ def pytest_addoption(parser: pytest.Parser):
         action="store",
         dest="skiptest",
         default=None,
-        help="Mark one or multiple, comma-separated, test names as skipped.",
+        help="Mark one or multiple, semicolon-separated, test names as skipped.",
+    )
+    select_group.addoption(
+        "--xfail-test",
+        action="store",
+        dest="xfailtest",
+        default=None,
+        help="Mark one or multiple, semicolon-separated, test names as xfail (expected to fail).",
     )
     select_group.addoption(
         "--select-fail-on-missing",
@@ -285,6 +305,16 @@ def pytest_addoption(parser: pytest.Parser):
         dest="selectfailonmissing",
         default=False,
         help="Fail instead of warn when not all (de-)selected tests could be found.",
+    )
+    select_group.addoption(
+        "--xfail-strict",
+        action="store_true",
+        dest="xfailstrict",
+        default=False,
+        help="Make xfail marks applied via --xfail-from-file/--xfail-test strict, so that an "
+        "unexpected pass (XPASS) fails the overall pytest run. By default (this flag unset), "
+        "xfail is non-strict, matching pytest's own default: XPASS is reported but does NOT "
+        "fail the run or change the exit code.",
     )
     select_group.addoption(
         "--num-shards",
@@ -318,17 +348,21 @@ def pytest_report_header(config) -> List[str]:  # pylint:disable = R1710
         for opt in option.value:
             if (value := config.getoption(opt)) is None:
                 continue
-            action = "selecting" if option == SelectOption.SELECT else "deselecting" if option == SelectOption.DESELECT else "skipping"
+            action = ("selecting" if option == SelectOption.SELECT else
+                      "deselecting" if option == SelectOption.DESELECT else
+                      "skipping" if option == SelectOption.SKIP else "xfailing")
             value = f"from '{value}'" if opt.endswith("file") else f"'{value}'"
             hdr.append(f"select: {action} tests {value}")
     if config.getoption("selectfailonmissing"):
         hdr.append("select: failing on missing selection items")
+    if config.getoption("xfailstrict"):
+        hdr.append("select: enforcing strict xfail (XPASS fails the run)")
     return hdr
 
 
 class SelectPlugin:
 
-    def pytest_collection_modifyitems(
+    def pytest_collection_modifyitems(  # pylint: disable=R0914
         self,
         session,  # pylint: disable=W0613
         config: pytest.Config,
@@ -346,17 +380,60 @@ class SelectPlugin:
             selected, deselected, skipped = items, [], []
         else:
             selected, deselected, skipped = [], [], []
-            select, deselect, skip = select_config.select, select_config.deselect, select_config.skip
+            select, deselect, skip, xfail = (
+                select_config.select,
+                select_config.deselect,
+                select_config.skip,
+                select_config.xfail,
+            )
+            xfail_strict = config.getoption("xfailstrict")
             for item in items:
                 if select is None or select.match_item(item):
                     selected.append(item)
-                if deselect and deselect.match_item(item) and selected and selected[-1] is item:
+                is_selected = bool(selected) and selected[-1] is item
+
+                # NOTE: `Matcher.match_item()` has the side effect of recording the
+                # matched name in `seen_test_names` (used for missing-test detection),
+                # independently of whether the corresponding action ends up being
+                # applied below. This is intentional: it lets `check_missing_tests()`
+                # correctly report "matched a real test" even when a name collision
+                # (see xfail handling below) means the action itself isn't applied.
+                deselect_matched = deselect is not None and deselect.match_item(item)
+                deselect_applied = deselect_matched and is_selected
+                if deselect_applied:
                     selected.pop()
                     deselected.append(item)
-                if skip and skip.match_item(item) and selected and selected[-1] is item:
+                    is_selected = False
+
+                skip_matched = skip is not None and skip.match_item(item)
+                skip_applied = skip_matched and is_selected
+                if skip_applied:
                     selected.pop()
                     skipped.append(item)
                     item.add_marker(pytest.mark.skip(reason="Skipped by pytest-skip"))
+                    is_selected = False
+
+                xfail_matched = xfail is not None and xfail.match_item(item)
+                if xfail_matched:
+                    if is_selected:
+                        item.add_marker(
+                            pytest.mark.xfail(reason="Xfailed by pytest-skip", strict=xfail_strict))
+                    else:
+                        # The name also matched --deselect-from-file/--deselect-test or
+                        # --skip-from-file/--skip-test (or the test was never selected in
+                        # the first place). This is a deliberate precedence decision:
+                        # select/deselect/skip win over xfail on a name collision, since
+                        # xfail only makes sense for a test whose body actually runs.
+                        # Surface the collision explicitly instead of silently dropping
+                        # the xfail request with zero signal to the user.
+                        reason = ("deselected" if deselect_applied else
+                                  "skipped" if skip_applied else "not selected")
+                        warnings.warn(
+                            UserWarning(
+                                f"pytest-skip: '{item.nodeid}' matched --xfail-from-file/"
+                                f"--xfail-test, but the test is {reason}; the xfail marker "
+                                "was NOT applied. select/deselect/skip take precedence over "
+                                "xfail when a test name collides across options."))
             self.select_config = select_config  # pylint: disable=W0201
 
         if sharding_config is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ pytest_plugins = ["pytester"]
 SELECT_OPT = "--select-from-file"
 DESELECT_OPT = "--deselect-from-file"
 SKIP_OPT = "--skip-from-file"
+XFAIL_OPT = "--xfail-from-file"
 
 
 @pytest.fixture

--- a/tests/test_pytest_skip.py
+++ b/tests/test_pytest_skip.py
@@ -3,7 +3,7 @@ import pytest
 
 from pytest import ExitCode
 from pytest_skip.plugin import Matcher
-from .conftest import SELECT_OPT, DESELECT_OPT, SKIP_OPT
+from .conftest import SELECT_OPT, DESELECT_OPT, SKIP_OPT, XFAIL_OPT
 
 # FIXME: this needs a refactoring where we make each test a structure
 # what contains the failing/passing combinations as a field
@@ -253,6 +253,81 @@ def test_missing_selection_file_fails(testdir, option_name):
             },
             [],
         ),
+        (
+            XFAIL_OPT,
+            ["{testfile}::test_a"],
+            0,
+            {
+                "xfailed": 2,
+                "xpassed": 2
+            },
+            [],
+        ),
+        (
+            XFAIL_OPT,
+            [
+                "{testfile}::test_a[1-2]",
+                "test_a[1-3]",
+                "test_a[3-1]",
+                "test_that_does_not_exist",
+            ],
+            0,
+            {
+                "passed": 2,
+                "xfailed": 2
+            },
+            [
+                r".*Not all tests to xfail exist.*",
+                r"\s+Missing test names to xfail:",
+                r"\s+- test_a\[3-1\]",
+                r"\s+- test_that_does_not_exist",
+            ],
+        ),
+        (
+            XFAIL_OPT,
+            ["test_a[r\"1-.*\"]@regexp"],
+            0,
+            {
+                "xfailed": 2,
+                "xpassed": 2
+            },
+            [],
+        ),
+        (
+            XFAIL_OPT,
+            ["test_a[r\".*-[2|3]\"]@regexp"],
+            0,
+            {
+                "passed": 2,
+                "xfailed": 2
+            },
+            [],
+        ),
+        (
+            XFAIL_OPT,
+            ["{testfile}::test_a[r\".*-[2|3]\"]@regexp"],
+            0,
+            {
+                "passed": 2,
+                "xfailed": 2
+            },
+            [],
+        ),
+        (
+            XFAIL_OPT,
+            [
+                "test_a[r\"1-1\"]@regexp",
+                "{testfile}::test_a[r\"1-2\"]@regexp",
+                "test_a[r\".*-3\"]@regexp",
+            ],
+            0,
+            {
+                "passed": 1,
+                "xpassed": 1,
+                "xfailed": 2
+            },
+            [],
+        ),
     ),
 )
 def test_tests_are_selected(  # pylint: disable=R0913, disable=R0917
@@ -426,6 +501,67 @@ def test_with_regexp_as_param(testdir, option_name, select_content, exit_code, o
     result.assert_outcomes(**outcomes)
 
 
+def test_xfail_reports_unexpected_pass_as_xpass(testdir):
+    # A test marked xfail by pytest-skip that still passes must be reported
+    # as XPASS (not PASSED), while the exit code stays green since xfail is
+    # not strict by default.
+    testfile = testdir.makefile(".py", TEST_CONTENT_PASS)
+    xfail_file = testdir.makefile(".txt", f"{testfile.relto(testdir.tmpdir)}::test_a[1-1-1]")
+    result = testdir.runpytest("-v", "-Walways", XFAIL_OPT, xfail_file)
+
+    assert result.ret == 0
+    result.assert_outcomes(passed=26, xpassed=1)
+    result.stdout.re_match_lines([r".*test_a\[1-1-1\] XPASS.*"])
+
+
+def test_xfail_strict_fails_run_on_unexpected_pass(testdir):
+    # With --xfail-strict, an unexpected pass on a test marked xfail by pytest-skip must
+    # fail the overall run (non-zero exit code), unlike the non-strict default above.
+    testfile = testdir.makefile(".py", TEST_CONTENT_PASS)
+    xfail_file = testdir.makefile(".txt", f"{testfile.relto(testdir.tmpdir)}::test_a[1-1-1]")
+    result = testdir.runpytest("-v", "-Walways", XFAIL_OPT, xfail_file, "--xfail-strict")
+
+    assert result.ret != 0
+    result.assert_outcomes(passed=26, failed=1)
+    result.stdout.re_match_lines([r".*test_a\[1-1-1\] FAILED.*"])
+
+
+def test_xfail_strict_does_not_affect_expected_failures(testdir):
+    # With --xfail-strict, a test that is marked xfail and genuinely fails is unaffected:
+    # it is still reported as XFAILED (not FAILED), regardless of strictness. TEST_CONTENT's
+    # other, unmarked failure (test_a[1-3]) still fails the run on its own, independent of
+    # --xfail-strict, so the overall exit code is non-zero for an unrelated reason - the
+    # point here is specifically that test_a[1-2] (the xfail-marked one) is NOT turned into
+    # a failure by --xfail-strict.
+    testfile = testdir.makefile(".py", TEST_CONTENT)
+    xfail_file = testdir.makefile(".txt", f"{testfile.relto(testdir.tmpdir)}::test_a[1-2]")
+    result = testdir.runpytest("-v", "-Walways", XFAIL_OPT, xfail_file, "--xfail-strict")
+
+    assert result.ret != 0
+    result.assert_outcomes(passed=2, failed=1, xfailed=1)
+    result.stdout.re_match_lines([r".*test_a\[1-2\] XFAIL.*"])
+
+
+@pytest.mark.parametrize("colliding_option", (SKIP_OPT, DESELECT_OPT))
+def test_xfail_collision_with_higher_precedence_option_warns(testdir, colliding_option):
+    # When a test name is listed in both --xfail-from-file and --skip-from-file (or
+    # --deselect-from-file), skip/deselect wins (the xfail marker is NOT applied), but this
+    # must not be a silent no-op: pytest-skip must emit an explicit warning naming the test
+    # and explaining that the xfail request was dropped due to the collision.
+    testfile = testdir.makefile(".py", TEST_CONTENT_PASS)
+    colliding_test = f"{testfile.relto(testdir.tmpdir)}::test_a[1-1-1]"
+    xfail_file = testdir.makefile(".xfail.txt", colliding_test)
+    colliding_file = testdir.makefile(".colliding.txt", colliding_test)
+    result = testdir.runpytest("-v", "-Walways", XFAIL_OPT, xfail_file, colliding_option,
+                               colliding_file)
+
+    assert result.ret == 0
+    result.stdout.re_match_lines([
+        r".*pytest-skip: '.*test_a\[1-1-1\]' matched --xfail-from-file/--xfail-test, but the "
+        r"test is (deselected|skipped); the xfail marker was NOT applied.*",
+    ])
+
+
 @pytest.mark.parametrize("skipfile_str,is_regexp,test_name,params,", [
     ("file.py::test_name[r\"param-match\"]@regexp", True, "file.py::test_name", "param-match"),
     ("test_name[r\"param-match\"]@regexp", True, "test_name", "param-match"),
@@ -511,3 +647,89 @@ def test_select_deselect_skip(testdir, select, deselect, skip, use_sharding):
     result = testdir.runpytest(*args)
     assert result.ret == ExitCode.OK if select else ExitCode.NO_TESTS_COLLECTED
     result.assert_outcomes(passed=len(select), deselected=len(deselect), skipped=len(skip))
+
+
+@pytest.mark.parametrize("select", (None, ("test_a", ), ("test_a[1-1-1]", ),
+                                    ("test_a[1-1-2]", "test_a[1-2-3]", "test_a[3-2-1]")))
+@pytest.mark.parametrize("deselect", (("test_a", ), ("test_a[1-1-2]", "test_a[1-2-3]")))
+@pytest.mark.parametrize("skip",
+                         (("test_a", ), ("test_a[3-3-3]", ), ("test_a[1-2-3]", "test_a[3-2-1]")))
+@pytest.mark.parametrize("xfail",
+                         (("test_a", ), ("test_a[3-3-3]", ), ("test_a[1-2-3]", "test_a[3-2-1]")))
+@pytest.mark.parametrize("use_sharding", (False, True))
+def test_select_deselect_skip_xfail(  # pylint: disable=R0913, disable=R0917
+        testdir,
+        select,
+        deselect,
+        skip,
+        xfail,
+        use_sharding,
+):
+    """
+    Extends test_select_deselect_skip with --xfail-from-file/--xfail-test to pin down, and
+    verify, the precedence decision for a name collision between xfail and
+    select/deselect/skip: when a test name is matched by both xfail and deselect/skip,
+    deselect/skip wins and the xfail marker is NOT applied to that test (it is either
+    excluded from the run entirely, or its body never executes, so an xfail marker on it
+    would be meaningless). Only names that remain selected (i.e. not deselected and not
+    skipped) after that resolution get the xfail marker applied. Since the generated test
+    always passes, a test that does get the xfail marker applied is reported as XPASS
+    rather than PASSED.
+
+    Reordering the skip/xfail checks, or disabling xfail marking entirely, must make this
+    test fail.
+    """
+    node_ids = [f"test_a[{a}-{b}-{c}]" for a, b, c in itertools.product((1, 2, 3), repeat=3)]
+    testfile = testdir.makefile(".py", TEST_CONTENT_PASS)
+    args = ["-v", "-Walways"]
+    if use_sharding:
+        args.append("--num-shards=1")
+        args.append("--shard-id=0")
+
+    def process_values(opt, values):
+        if values is None:
+            return set(node_ids) if opt is SELECT_OPT else set()
+        sfx = ("select" if opt is SELECT_OPT else
+               "deselect" if opt is DESELECT_OPT else "skip" if opt is SKIP_OPT else "xfail")
+        mid = len(values) // 2
+        files = [
+            testdir.makefile(
+                f".{sfx}{i}.txt",
+                l.format(testfile=testfile.relto(testdir.tmpdir)),
+            ).strpath for i, l in enumerate(values[:mid])
+        ]
+        names = values[mid:]
+        if files:
+            args.extend([opt, ";".join(files)])
+        if names:
+            args.extend([f"{opt[:-9]}test", ";".join(names)])
+        return set(node_ids) if "test_a" in values else set(values)
+
+    select = process_values(SELECT_OPT, select)
+    deselect = process_values(DESELECT_OPT, deselect)
+    skip = process_values(SKIP_OPT, skip)
+    xfail = process_values(XFAIL_OPT, xfail)
+    deselect.intersection_update(select)
+    skip.intersection_update(select)
+    select.difference_update(deselect)
+    skip.difference_update(deselect)
+    select.difference_update(skip)
+
+    # Precedence pinned down here: select/deselect/skip take priority over xfail on a name
+    # collision, so xfail only ends up applied to names still selected after deselect/skip
+    # resolution above. Any xfail name that collided with a deselected/skipped name is
+    # dropped from `xfail` (mirroring the plugin's actual behavior) rather than counted.
+    xfail.intersection_update(select)
+    select.difference_update(xfail)
+
+    result = testdir.runpytest(*args)
+    # A test is still "collected" (contributing to a normal, non-NO_TESTS_COLLECTED exit)
+    # if it ends up passed, skipped, or xpassed, only full deselection empties the run.
+    # skip/xfail never remove an item from collection, they just change how it's reported.
+    assert result.ret == (ExitCode.OK if (select or skip or xfail) else ExitCode.NO_TESTS_COLLECTED)
+    result.assert_outcomes(
+        passed=len(select),
+        deselected=len(deselect),
+        skipped=len(skip),
+        xpassed=len(xfail),
+    )

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -3,7 +3,7 @@ import functools
 from typing import Optional
 import pytest
 
-from .conftest import SELECT_OPT, DESELECT_OPT, SKIP_OPT
+from .conftest import SELECT_OPT, DESELECT_OPT, SKIP_OPT, XFAIL_OPT
 
 
 @functools.lru_cache
@@ -66,8 +66,8 @@ def extract_test_names(outlines: list[str]) -> dict[str, list[str]]:
         "SKIPPED": ["file.py::test_2[param2]", "file.py::test_2[param3]"],
     }
     """
-    regexp = re.compile(r"^(.*) (FAILED|PASSED|SKIPPED).*\[\s*\d+%\]$")
-    test_names: dict[str, list[str]] = {"FAILED": [], "PASSED": [], "SKIPPED": []}
+    regexp = re.compile(r"^(.*) (FAILED|PASSED|SKIPPED|XPASS).*\[\s*\d+%\]$")
+    test_names: dict[str, list[str]] = {"FAILED": [], "PASSED": [], "SKIPPED": [], "XPASS": []}
     for line in outlines:
         line = line.strip()
         match = re.match(regexp, line)
@@ -118,13 +118,21 @@ def assert_sharding(  # pylint: disable=too-many-arguments, too-many-locals, too
     test_name: str,
     extra_pytest_args: Optional[list] = None,
     passed_tests_per_shard: Optional[list[str]] = None,
-) -> dict[str, list[str]]:
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """
     Run pytest with sharding and (optionally) extra CLI args per shard.
-    Returns a dictionary with passed tests as a key and their parameters as a value.
-    Output example: {"file.py::test": ["1", "2"], "file.py::test_2": ["1-1", "1-2"]}
+
+    Returns a 2-tuple:
+      - a dictionary with passed-or-xpassed tests as a key and their parameters as a value
+        (XPASS is folded into this bucket since, from a "did the shard select/run it"
+        perspective, both are part of the selected/executed tests).
+        Output example: {"file.py::test": ["1", "2"], "file.py::test_2": ["1-1", "1-2"]}
+      - a dictionary with only the xpassed tests, in the same shape, so callers can verify
+        which (if any) specific tests were actually marked xfail and unexpectedly passed,
+        rather than only the merged/aggregate count.
     """
     combined_outputs: dict[str, list[str]] = {}
+    combined_xpass: dict[str, list[str]] = {}
 
     if num_selected > num_shards:
         shard_sizes = {
@@ -149,7 +157,11 @@ def assert_sharding(  # pylint: disable=too-many-arguments, too-many-locals, too
                                          [])) == num_not_passed_per_shard.get("FAILED", 0)
         assert len(grouped["SKIPPED"].get(test_name,
                                           [])) == num_not_passed_per_shard.get("SKIPPED", 0)
-        out = grouped["PASSED"]
+        # Tests marked xfail by pytest-skip that still pass are reported as
+        # XPASS rather than PASSED, but they are still part of the shard's
+        # selected/executed tests, so fold them back in here.
+        out = merge_list_dicts(dict(grouped["PASSED"]), grouped["XPASS"])
+        combined_xpass = merge_list_dicts(combined_xpass, dict(grouped["XPASS"]))
 
         if len(out) == 0:
             assert is_empty_shard
@@ -168,7 +180,7 @@ def assert_sharding(  # pylint: disable=too-many-arguments, too-many-locals, too
 
         combined_outputs = merge_list_dicts(combined_outputs, out)
 
-    return combined_outputs
+    return combined_outputs, combined_xpass
 
 
 # ===== Tests =====
@@ -183,7 +195,7 @@ def test_even_sharding(testdir, num_tests, num_shards, sharding_mode):
     testdir.makefile(".py", test_content)
     test_name = f"test_even_sharding.py::{case_name}"
 
-    combined_outputs = assert_sharding(
+    combined_outputs, combined_xpass = assert_sharding(
         testdir,
         num_not_passed_per_shard={
             "FAILED": 0,
@@ -198,6 +210,9 @@ def test_even_sharding(testdir, num_tests, num_shards, sharding_mode):
         ],
     )
 
+    # No xfail option is used here, so no test should ever surface as XPASS.
+    assert not combined_xpass
+
     if len(combined_outputs) == 0:
         assert num_tests == 0
         return
@@ -211,7 +226,7 @@ def test_even_sharding(testdir, num_tests, num_shards, sharding_mode):
     assert test_set == set(map(str, range(num_tests)))
 
 
-@pytest.mark.parametrize("select_option", [SELECT_OPT, DESELECT_OPT, SKIP_OPT])
+@pytest.mark.parametrize("select_option", [SELECT_OPT, DESELECT_OPT, SKIP_OPT, XFAIL_OPT])
 @pytest.mark.parametrize("sharding_mode", ["contiguous-split", "round-robin"])
 def test_tests_are_selected_with_sharding(testdir, select_option, sharding_mode):  # pylint: disable=too-many-locals
     num_tests = 32
@@ -230,6 +245,14 @@ def test_tests_are_selected_with_sharding(testdir, select_option, sharding_mode)
     elif select_option in (DESELECT_OPT, SKIP_OPT):
         num_selected_tests = num_tests - len(select_cases)
         passed_cases = set(map(str, range(num_tests))) - set(select_cases)
+    elif select_option == XFAIL_OPT:
+        # xfail doesn't remove tests from the run (unlike deselect/skip), it
+        # only marks the matched ones as expected-to-fail. Since the
+        # generated test always passes, those marked tests are still
+        # selected and sharded as usual, they just surface as XPASS instead
+        # of PASSED.
+        num_selected_tests = num_tests
+        passed_cases = set(map(str, range(num_tests)))
     else:
         assert False, f"Unknown select option: {select_option}"
 
@@ -239,7 +262,7 @@ def test_tests_are_selected_with_sharding(testdir, select_option, sharding_mode)
         *[line.format(testfile=testfile.relto(testdir.tmpdir)) for line in select_content],
     )
 
-    combined_passed = assert_sharding(
+    combined_passed, combined_xpass = assert_sharding(
         testdir,
         num_not_passed_per_shard={
             "FAILED": 0,
@@ -251,6 +274,17 @@ def test_tests_are_selected_with_sharding(testdir, select_option, sharding_mode)
         test_name=test_name,
         extra_pytest_args=[select_option, select_file, "--sharding-mode", sharding_mode],
     )
+
+    # This is the crux of xfail-under-sharding coverage: it's not enough for the
+    # aggregate pass-count to be unchanged (that would hold identically whether xfail
+    # marking under sharding works, is broken, or was never wired in at all). Assert that
+    # the XPASS bucket actually contains exactly the xfail-matched test names when
+    # --xfail-from-file is used, and is empty for every other option.
+    if select_option == XFAIL_OPT:
+        assert combined_xpass[test_name]
+        assert set(combined_xpass[test_name]) == set(select_cases)
+    else:
+        assert not combined_xpass
 
     if len(combined_passed) == 0:
         assert num_tests == 0
@@ -290,7 +324,7 @@ def test_sharding_modes(testdir, mode, tests_per_shard):
     test_name = f"test_sharding_modes.py::{case_name}"
     testdir.makefile(".py", test_content)
 
-    combined_outputs = assert_sharding(
+    combined_outputs, combined_xpass = assert_sharding(
         testdir,
         num_not_passed_per_shard={
             "FAILED": 0,
@@ -305,6 +339,9 @@ def test_sharding_modes(testdir, mode, tests_per_shard):
         ],
         passed_tests_per_shard=tests_per_shard,
     )
+
+    # No xfail option is used here, so no test should ever surface as XPASS.
+    assert not combined_xpass
 
     if len(combined_outputs) == 0:
         assert num_tests == 0


### PR DESCRIPTION
## What this adds

A new `--xfail-from-file`/`--xfail-test` option, complementing the existing `--skip-from-file`/`--skip-test`. The difference: skip means the test body never runs; xfail means the body runs and a failure is expected, with an unexpected pass reported as `XPASS`. Useful for tracking known failures without hiding whether they've silently started passing again.

Requested by a downstream consumer (intel/intel-xpu-backend-for-triton), tracked at intel/intel-xpu-backend-for-triton#7726.

## Details

- `--xfail-from-file`/`--xfail-test` mirror the skip option's CLI shape and file format (exact names + `@regexp`).
- `--xfail-strict` (optional): passes `strict=True` through, so an unexpected pass fails the run, for projects that want that.
- select/deselect/skip take precedence over xfail on a name collision (deliberate, warned on, and tested, not left as an accident of code order).
- Fixed `--skip-test`'s help text (said "comma-separated," actually semicolon-separated).
- Tests: basic xfail, regexp matching, XPASS reporting, collision precedence (combinatorial), sharding, and strict mode.
- README updated, including an explicit note that XPASS does not fail the run by default (matches pytest's own default).

## Side note

`pytest-skip` might be worth renaming now that it covers more than "skip" (e.g. `pytest-select`, matching the internal `SelectOption` enum), just a thought for you to consider, not something I've acted on.